### PR TITLE
Added code to render json:api error responses on failed authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ _UpgradeReport_Files/
 Thumbs.db
 Desktop.ini
 .DS_Store
+
+*.log

--- a/src/JsonApiDotNetCore.Demo.Auth.Api/ErrorResponseWriter.cs
+++ b/src/JsonApiDotNetCore.Demo.Auth.Api/ErrorResponseWriter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using JsonApiDotNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
+
+namespace JsonApiDotNetCore.Demo.Auth.Api
+{
+    internal sealed class ErrorResponseWriter
+    {
+        private readonly IExceptionHandler _exceptionHandler;
+
+        public ErrorResponseWriter(IExceptionHandler exceptionHandler)
+        {
+            _exceptionHandler = exceptionHandler ?? throw new ArgumentNullException(nameof(exceptionHandler));
+        }
+
+        public async Task RenderExceptionAsync(Exception exception, HttpResponse httpResponse)
+        {
+            var errorDocument = _exceptionHandler.HandleException(exception);
+            string responseContent = JsonConvert.SerializeObject(errorDocument);
+
+            httpResponse.ContentType = HeaderConstants.MediaType;
+            httpResponse.StatusCode = (int) errorDocument.GetErrorStatusCode();
+
+            await httpResponse.WriteAsync(responseContent);
+            await httpResponse.CompleteAsync();
+        }
+    }
+}

--- a/src/JsonApiDotNetCore.Demo.Auth.Api/ExceptionMiddleware.cs
+++ b/src/JsonApiDotNetCore.Demo.Auth.Api/ExceptionMiddleware.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+using JsonApiDotNetCore.Middleware;
+using Microsoft.AspNetCore.Http;
+
+namespace JsonApiDotNetCore.Demo.Auth.Api
+{
+    internal sealed class ExceptionMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ErrorResponseWriter _errorResponseWriter;
+
+        public ExceptionMiddleware(IExceptionHandler exceptionHandler, RequestDelegate next)
+        {
+            _next = next;
+            _errorResponseWriter = new ErrorResponseWriter(exceptionHandler);
+        }
+
+        public async Task Invoke(HttpContext httpContext)
+        {
+            try
+            {
+                await _next(httpContext);
+            }
+            catch (Exception exception)
+            {
+                await _errorResponseWriter.RenderExceptionAsync(exception, httpContext.Response);
+            }
+        }
+    }
+}

--- a/src/JsonApiDotNetCore.Demo.Auth.Api/Startup.cs
+++ b/src/JsonApiDotNetCore.Demo.Auth.Api/Startup.cs
@@ -56,7 +56,10 @@ namespace JsonApiDotNetCore.Demo.Auth.Api
             {
                 loggerFactory.AddFile("logs/log_{Date}.txt");
             }
-            
+
+            // Uncomment the next line to catch exceptions thrown from authentication.
+            //app.UseMiddleware<ExceptionMiddleware>();
+
             app.UseRouting();
             
             app.UseAuthentication();


### PR DESCRIPTION
Answer to the question at https://github.com/json-api-dotnet/JsonApiDotNetCore/issues/950.

Added code to render json:api error responses on failed authentication. See code comments in diff.

The simplest approach is to render an error response on authentication failure.

Another approach is to intercept all exceptions via middleware. If the project contains non-json:api endpoints (such as static documentation, health checks etc), this may not be appropriate.